### PR TITLE
Add debug toggle for split-by-Ns intermediates

### DIFF
--- a/00_split_by_Ns.smk
+++ b/00_split_by_Ns.smk
@@ -183,7 +183,11 @@ def _as_bool(x, default=False):
         return False
     raise ValueError(f"Cannot interpret boolean value from '{x}'")
 
-CLEANUP_CHUNK_INTERMEDIATES = _as_bool(config.get("cleanup_chunk_intermediates", True), True)
+DEBUG_KEEP_INTERMEDIATES = _as_bool(config.get("debug_keep_intermediates", False), False)
+CLEANUP_CHUNK_INTERMEDIATES = _as_bool(
+    config.get("cleanup_chunk_intermediates", not DEBUG_KEEP_INTERMEDIATES),
+    not DEBUG_KEEP_INTERMEDIATES,
+)
 RHO_ONLY = _as_bool(config.get("rho_only", False), False)
 
 # Rho mode:
@@ -224,7 +228,10 @@ if CNE_EXTRACT_FORMAT in {"fa", "fna"}:
 if CNE_EXTRACT_FORMAT not in {"fasta", "maf"}:
     raise ValueError("cne_extract_format must be 'fasta' or 'maf'.")
 CNE_FASTA_HEADER = str(config.get("cne_fasta_header", "species-coords-id")).strip()
-KEEP_CNEE_SIDECARS = _as_bool(config.get("keep_cnee_sidecars", False), False)
+KEEP_CNEE_SIDECARS = _as_bool(
+    config.get("keep_cnee_sidecars", DEBUG_KEEP_INTERMEDIATES),
+    DEBUG_KEEP_INTERMEDIATES,
+)
 
 ALL_BED_TARGETS = expand(
     os.path.join(CONSERVE_DIR, "{chromosome_group}", "{ref_chromosome}.phastcon-conserved.bed"),

--- a/cfgs/rho-phastcon-test.yaml
+++ b/cfgs/rho-phastcon-test.yaml
@@ -66,6 +66,10 @@ make_cnees: true
 make_cnee_mafs: true
 # (false, if not needed) If true, create 07-CNEE_mafs/{group}/{chrom}/ with one MAF per CNEE and a manifest.txt.
 
+debug_keep_intermediates: false
+# If true, keep large intermediate files and sidecars for debugging.
+# If false, delete chunk-level intermediates and extra sidecars after final outputs are produced.
+
 cnee_ces_merge_gap_bp: 5
 # Merge conserved-element intervals within this bp gap before CDS subtraction to make CNEEs.
 


### PR DESCRIPTION
This PR adds a user-facing config flag, `debug_keep_intermediates`, to control whether the split-by-Ns workflow keeps or cleans intermediate files.

Behavior:
- `debug_keep_intermediates: true` keeps chunk intermediates and sidecar files for debugging
- `debug_keep_intermediates: false` cleans bulky intermediates after final outputs are produced

Implementation:
- `cleanup_chunk_intermediates` now defaults to `not debug_keep_intermediates`
- `keep_cnee_sidecars` now defaults to `debug_keep_intermediates`

This keeps debugging and production behavior consistent while still allowing explicit overrides of the lower-level cleanup options if needed.
